### PR TITLE
Make this work with the new endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mojfile-uploader-api-client (0.1.0)
+    mojfile-uploader-api-client (0.1.1)
       rest-client (~> 2.0.0)
 
 GEM
@@ -25,7 +25,7 @@ GEM
       equalizer (~> 0.0.9)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20161021)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     http-cookie (1.0.3)

--- a/lib/mojfile_uploader_api_client/status.rb
+++ b/lib/mojfile_uploader_api_client/status.rb
@@ -6,17 +6,17 @@ module MojFileUploaderApiClient
     end
 
     def endpoint
-      'status'
+      'healthcheck'
     end
 
     def available?
-      response.success? && status.eql?('OK')
+      response.success? && status.eql?('ok')
     end
 
     private
 
     def status
-      response.body&.fetch(:status)
+      response.body&.fetch(:service_status)
     end
   end
 end

--- a/lib/mojfile_uploader_api_client/version.rb
+++ b/lib/mojfile_uploader_api_client/version.rb
@@ -1,3 +1,3 @@
 module MojFileUploaderApiClient
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/mojfile_uploader_api_client/status_spec.rb
+++ b/spec/mojfile_uploader_api_client/status_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 RSpec.describe MojFileUploaderApiClient::Status do
   let(:client) { RestClient::Request }
-  let(:response) { instance_double('Response', code: 200, body: '{}') }
+  # It also returns the status of the services it depends on, but this is
+  # sufficient for the purposes of the spec.
+  let(:response_body) { { service_status: 'ok' }.to_json }
+  let(:response) { instance_double('Response', code: 200, body: response_body) }
 
   subject { described_class.new }
 
@@ -11,7 +14,7 @@ RSpec.describe MojFileUploaderApiClient::Status do
   end
 
   context 'endpoint' do
-    let(:expected_endpoint) { 'status' }
+    let(:expected_endpoint) { 'healthcheck' }
 
     it 'should return the endpoint' do
       expect(subject.endpoint).to eq(expected_endpoint)
@@ -19,7 +22,7 @@ RSpec.describe MojFileUploaderApiClient::Status do
   end
 
   context 'URL' do
-    let(:expected_url) { 'http://example.com/status' }
+    let(:expected_url) { 'http://example.com/healthcheck' }
 
     it 'should build the full URL using base_url and endpoint' do
       expect(client).to receive(:execute).with(hash_including(url: expected_url))
@@ -45,8 +48,6 @@ RSpec.describe MojFileUploaderApiClient::Status do
 
   describe '#available?' do
     context 'for a successful response with body' do
-      let(:response) { instance_double('Response', code: 200, body: "{\"status\":\"OK\"}") }
-
       it 'should be true' do
         subject.call
         expect(subject.available?).to eq(true)
@@ -57,7 +58,7 @@ RSpec.describe MojFileUploaderApiClient::Status do
         response = subject.response
 
         expect(response.code).to eq(200)
-        expect(response.body).to eq({status: 'OK'})
+        expect(response.body).to eq({service_status: 'ok'})
       end
     end
 


### PR DESCRIPTION
The file uploader now returns a json hash containing information about
the status of the service and the services it depends on. This change
brings the api client in line with new format of the response.