### PR TITLE
Tweak Reponse class to fail on unparsable JSON

### DIFF
--- a/spec/mojfile_uploader_api_client/http_client_spec.rb
+++ b/spec/mojfile_uploader_api_client/http_client_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
   subject { described_class.new }
 
   let(:client) { RestClient::Request }
-  let(:response) { instance_double('Response', code: 200, body: '{}') }
+  let(:client_response) { instance_double('Response', code: 200, body: '{}') }
 
   describe 'default options' do
     it 'should have a default set of client options' do
@@ -79,7 +79,7 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
     before(:each) do
       allow(subject).to receive(:verb).and_return(:get)
       allow(subject).to receive(:endpoint).and_return('/test')
-      allow(client).to receive(:execute).and_return(response)
+      allow(client).to receive(:execute).and_return(client_response)
     end
 
     # URL is being tested in subclass specs but Mutant is a bit picky and want it to be covered also here.
@@ -156,24 +156,24 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
     end
 
     context 'request unsuccessful with body' do
-      let(:response) { instance_double('Response', code: 404, body: 'boom') }
+      let(:client_response) { instance_double('Response', code: 404, body: 'boom') }
 
       it 'success? should be false' do
         subject.call
         expect(subject.response.success?).to eq(false)
       end
 
-      it 'should have a code and a body' do
+      it 'should have a code and fail on body' do
         subject.call
         response = subject.response
 
         expect(response.code).to eq(404)
-        expect(response.body).to eq({body_parser_error: "743: unexpected token at 'boom'"})
+        expect { response.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
       end
     end
 
     context 'request unsuccessful with body blank' do
-      let(:response) { instance_double('Response', code: 404, body: '') }
+      let(:client_response) { instance_double('Response', code: 404, body: '') }
 
       it 'success? should be false' do
         subject.call
@@ -185,12 +185,12 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
         response = subject.response
 
         expect(response.code).to eq(404)
-        expect(response.body).to eq('')
+        expect(response.body).to eq(nil)
       end
     end
 
     context 'request unsuccessful without body' do
-      let(:response) { instance_double('Response', code: 404, body: nil) }
+      let(:client_response) { instance_double('Response', code: 404, body: nil) }
 
       it 'success? should be false' do
         subject.call

--- a/spec/mojfile_uploader_api_client/response_spec.rb
+++ b/spec/mojfile_uploader_api_client/response_spec.rb
@@ -1,85 +1,62 @@
 require 'spec_helper'
 
 RSpec.describe MojFileUploaderApiClient::Response do
-
   subject { described_class.new(code: code, body: body) }
 
-  describe 'successful responses' do
-    let(:code) { 200 }
-    let(:body) { {result: 'ok'}.to_json }
+  let(:body) { nil }
+  let(:code) { nil }
 
-    it 'has a body' do
-      expect(subject.body).to eq({result: 'ok'})
+  describe '#body' do
+    describe 'when the response body is parsable' do
+      let(:body) { {result: 'ok'}.to_json }
+
+      it { is_expected.to have_attributes(body: {result: 'ok'}) }
     end
 
-    context '200 code' do
+    describe 'when the response body is nil' do
+      let(:body) { nil }
+
+      it { is_expected.to have_attributes(body: nil) }
+    end
+
+    describe 'when the response body is empty' do
+      let(:body) { '' }
+
+      it { is_expected.to have_attributes(body: nil) }
+    end
+
+    describe 'when the response body is unparsable' do
+      let(:body) { 'sadifuygwi3P982(*#Q$&(*' }
+
+      it 'raises an error' do
+        expect { subject.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
+      end
+    end
+  end
+
+  describe '#code' do
+    describe 'when the response is a 200' do
       let(:code) { 200 }
 
-      it 'has a code' do
-        expect(subject.code).to eq(200)
-      end
-
+      it { is_expected.to have_attributes(code: 200) }
       it { is_expected.to be_success }
       it { is_expected.to_not be_error }
     end
 
-    context '204 code' do
+    describe 'when the response is a 204' do
       let(:code) { 204 }
 
-      it 'has a code' do
-        expect(subject.code).to eq(204)
-      end
-
+      it { is_expected.to have_attributes(code: 204) }
       it { is_expected.to be_success }
       it { is_expected.to_not be_error }
     end
-  end
 
-  describe 'unsuccessful response' do
-    let(:code) { 404 }
-    let(:body) { 'not found' }
+    describe 'when the response is an error code' do
+      let(:code) { 404 }
 
-    it 'has a code' do
-      expect(subject.code).to eq(404)
+      it { is_expected.to have_attributes(code: 404) }
+      it { is_expected.to_not be_success }
+      it { is_expected.to be_error }
     end
-
-    it 'has a body' do
-      expect(subject.body).to eq({body_parser_error: "743: unexpected token at 'not found'"})
-    end
-
-    it { is_expected.to_not be_success }
-    it { is_expected.to be_error }
-  end
-
-  describe 'blank body response' do
-    let(:code) { 200 }
-    let(:body) { '' }
-
-    it 'has a code' do
-      expect(subject.code).to eq(200)
-    end
-
-    it 'has blank body' do
-      expect(subject.body).to eq('')
-    end
-
-    it { is_expected.to be_success }
-    it { is_expected.to_not be_error }
-  end
-
-  describe 'no body response' do
-    let(:code) { 200 }
-    let(:body) { nil }
-
-    it 'has a code' do
-      expect(subject.code).to eq(200)
-    end
-
-    it 'has nil body' do
-      expect(subject.body).to be_nil
-    end
-
-    it { is_expected.to be_success }
-    it { is_expected.to_not be_error }
   end
 end

--- a/spec/mojfile_uploader_api_client/status_spec.rb
+++ b/spec/mojfile_uploader_api_client/status_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe MojFileUploaderApiClient::Status do
   let(:client) { RestClient::Request }
   # It also returns the status of the services it depends on, but this is
   # sufficient for the purposes of the spec.
-  let(:response_body) { { service_status: 'ok' }.to_json }
-  let(:response) { instance_double('Response', code: 200, body: response_body) }
+  let(:client_response_body) { { service_status: 'ok' }.to_json }
+  let(:client_response) { instance_double('Response', code: 200, body: client_response_body) }
 
   subject { described_class.new }
 
   before(:each) do
-    allow(client).to receive(:execute).and_return(response)
+    allow(client).to receive(:execute).and_return(client_response)
   end
 
   context 'endpoint' do
@@ -63,7 +63,7 @@ RSpec.describe MojFileUploaderApiClient::Status do
     end
 
     context 'for a successful response without body' do
-      let(:response) { instance_double('Response', code: 200, body: nil) }
+      let(:client_response) { instance_double('Response', code: 200, body: nil) }
 
       it 'should be false' do
         subject.call
@@ -80,24 +80,24 @@ RSpec.describe MojFileUploaderApiClient::Status do
     end
 
     context 'for an unsuccessful response with body' do
-      let(:response) { instance_double('Response', code: 500, body: 'boom') }
+      let(:client_response) { instance_double('Response', code: 500, body: 'boom') }
 
       it 'should be false' do
         subject.call
         expect(subject.available?).to eq(false)
       end
 
-      it 'should have a code and a body' do
+      it 'should have a code and fail on body' do
         subject.call
         response = subject.response
 
         expect(response.code).to eq(500)
-        expect(response.body).to eq({body_parser_error: "743: unexpected token at 'boom'"})
+        expect { response.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
       end
     end
 
     context 'for an unsuccessful response without body' do
-      let(:response) { instance_double('Response', code: 500, body: nil) }
+      let(:client_response) { instance_double('Response', code: 500, body: nil) }
 
       it 'should be false' do
         subject.call


### PR DESCRIPTION
There's no reason for the `Response` class to swallow
`JSON::ParserError` - it's not something expected or recoverable from.

- Add `Response::UnparsableResponseError` which is raised if JSON
  parsing fails
- Clean up `Response` class to only parse body when required instead
  of on initialisation
- Clean up specs to make it obvious what is a `Response` object, and
  what is the response from the HTTP client