### PR TITLE
Add convenience methods to main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ end
 #### When a previous collection reference is known:
 
 ```ruby
+MojFileUploaderApiClient.add_file(title: 'test', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757')
+=> {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757", :key=>"7c6aca2c-eb7a-4194-8166-9fd6ac82127b.test.txt"}
+```
+
+Or you can use the `AddFile` client directly:
+
+```ruby
 MojFileUploaderApiClient::AddFile.new(title: 'test', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757').call
 
 => #<MojFileUploaderApiClient::Response:0x007fe4e5c85ce0
@@ -29,6 +36,13 @@ MojFileUploaderApiClient::AddFile.new(title: 'test', filename: 'test.txt', data:
 ```
 
 #### No previous collection reference (will create a new one):
+
+```ruby
+MojFileUploaderApiClient.add_file(title: 'test', filename: 'test.txt', data: 'bla bla bla')
+=> {:collection=>"741635f7-488a-49cc-a3f1-9ee38795e28e", :key=>"0543a21d-e884-4076-89be-41cc09b00da1.test.txt"}
+```
+
+Or you can use the `AddFile` client directly:
 
 ```ruby
 MojFileUploaderApiClient::AddFile.new(title: 'test', filename: 'test.txt', data: 'bla bla bla').call
@@ -41,6 +55,13 @@ MojFileUploaderApiClient::AddFile.new(title: 'test', filename: 'test.txt', data:
 ### Delete a file
 
 ```ruby
+MojFileUploaderApiClient.delete_file(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757', filename: 'test1.txt')
+=> RequestError
+```
+
+Or you can use the `DeleteFile` client directly:
+
+```ruby
 MojFileUploaderApiClient::DeleteFile.new(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757', filename: 'test1.txt').call
 => #<MojFileUploaderApiClient::Response:0x007fe4e59c8098 @body={:body_parser_error=>"743: unexpected token at ''"}, @code=204>
 ```
@@ -48,11 +69,19 @@ MojFileUploaderApiClient::DeleteFile.new(collection_ref: 'a45c556f-a628-41d3-8c2
 ### List files
 
 ```ruby
+MojFileUploaderApiClient.list_files(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757')
+=> {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757",
+    :files=>[{:key=>"a45c556f-a628-41d3-8c29-351f84e63757/test1.txt", :title=>"test1.txt", :last_modified=>"2016-11-30T15:30:52.000Z"}]}
+```
+
+Or you can use the `ListFiles` client directly:
+
+```ruby
 MojFileUploaderApiClient::ListFiles.new(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757').call
 => #<MojFileUploaderApiClient::Response:0x007fe4e5ac91e0
  @body=
   {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757",
-   :files=>[{:key=>"a45c556f-a628-41d3-8c29-351f84e63757/test1.txt", :title=>"test1.txt", :last_modified=>"2016-11-30T15:30:52.000Z"}]},
+   :files=>[{:key=>"a45c556f-a628-41d3-8c29-351f84e63757/test1.txt", :title=>"test1.txt", :last_modified=>"2016-11-30T15:30:52.000Z"}]}
  @code=200>
 ```
 

--- a/lib/mojfile_uploader_api_client.rb
+++ b/lib/mojfile_uploader_api_client.rb
@@ -10,6 +10,8 @@ require 'mojfile_uploader_api_client/delete_file'
 require 'mojfile_uploader_api_client/list_files'
 
 module MojFileUploaderApiClient
+  INFECTED_FILE_RESPONSE_CODE = 400
+
   class Unavailable < StandardError; end
   class RequestError < StandardError; end
   class InfectedFileError < StandardError; end
@@ -19,7 +21,7 @@ module MojFileUploaderApiClient
 
     if response.success?
       response.body
-    elsif response.code.equal?(400)
+    elsif response.code.equal?(INFECTED_FILE_RESPONSE_CODE)
       raise InfectedFileError
     else
       raise RequestError

--- a/lib/mojfile_uploader_api_client.rb
+++ b/lib/mojfile_uploader_api_client.rb
@@ -12,4 +12,31 @@ require 'mojfile_uploader_api_client/list_files'
 module MojFileUploaderApiClient
   class Unavailable < StandardError; end
   class RequestError < StandardError; end
+  class InfectedFileError < StandardError; end
+
+  def self.add_file(params)
+    response = AddFile.new(params).call
+
+    if response.success?
+      response.body
+    elsif response.code.equal?(400)
+      raise InfectedFileError
+    else
+      raise RequestError
+    end
+  end
+
+  def self.delete_file(params)
+    response = DeleteFile.new(params).call
+
+    raise RequestError unless response.success?
+    response.body
+  end
+
+  def self.list_files(params)
+    response = ListFiles.new(params).call
+
+    raise RequestError unless response.success?
+    response.body
+  end
 end

--- a/spec/mojfile_uploader_api_client_spec.rb
+++ b/spec/mojfile_uploader_api_client_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+RSpec.describe MojFileUploaderApiClient do
+  subject(:client) { described_class }
+
+  let(:response) { instance_double(MojFileUploaderApiClient::Response, success?: success, code: code) }
+  let(:client_object) { instance_double(client_class) }
+  let(:body) { double('body') }
+
+  before do
+    expect(client_class).to receive(:new).with(params).and_return(client_object)
+    expect(client_object).to receive(:call).and_return(response)
+  end
+
+  describe '.add_file' do
+    let(:client_class) { MojFileUploaderApiClient::AddFile }
+    let(:params) {{
+      collection_ref: '123',
+      title: 'title',
+      filename: 'filename',
+      data: 'data'
+    }}
+
+    context 'when the response is successful' do
+      let(:success) { true }
+      let(:code) { 200 }
+
+      it 'returns the body' do
+        expect(response).to receive(:body).and_return(body)
+        expect(client.add_file(params)).to eq(body)
+      end
+    end
+
+    context 'when the response is unsuccessful (virus infected file)' do
+      let(:success) { false }
+      let(:code) { 400 }
+
+      it 'raises InfectedFileError' do
+        expect { client.add_file(params) }.to raise_error(MojFileUploaderApiClient::InfectedFileError)
+      end
+    end
+
+    context 'when the response is unsuccessful (other error)' do
+      let(:success) { false }
+      let(:code) { 402 }
+
+      it 'raises RequestError' do
+        expect { client.add_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+      end
+    end
+  end
+
+  describe '.delete_file' do
+    let(:client_class) { MojFileUploaderApiClient::DeleteFile }
+    let(:params) {{
+      collection_ref: '123',
+      filename: 'filename',
+    }}
+
+    context 'when the response is successful' do
+      let(:success) { true }
+      let(:code) { 200 }
+
+      it 'returns the body' do
+        expect(response).to receive(:body).and_return(body)
+        expect(client.delete_file(params)).to eq(body)
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:success) { false }
+      let(:code) { 402 }
+
+      it 'raises RequestError' do
+        expect { client.delete_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+      end
+    end
+  end
+
+  describe '.list_files' do
+    let(:client_class) { MojFileUploaderApiClient::ListFiles }
+    let(:params) {{
+      collection_ref: '123'
+    }}
+
+    context 'when the response is successful' do
+      let(:success) { true }
+      let(:code) { 200 }
+
+      it 'returns the body' do
+        expect(response).to receive(:body).and_return(body)
+        expect(client.list_files(params)).to eq(body)
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:success) { false }
+      let(:code) { 402 }
+
+      it 'raises RequestError' do
+        expect { client.list_files(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the following convenience methods to `MojFileUploaderApiClient`:
- `add_file`
- `delete_file`
- `list_files`

These call their respective action classes, and retrieve the body if the
request was successful – and raise an appropriate error if it wasn't.

This saves us having to call the classes in client code, and having to
deal with HTTP responses etc.