### PR TITLE
Enable uploader folder support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mojfile-uploader-api-client (0.1.1)
+    mojfile-uploader-api-client (0.3)
       rest-client (~> 2.0.0)
 
 GEM
@@ -68,7 +68,7 @@ GEM
       rspec-core (>= 3.4.0, < 3.6.0)
     netrc (0.11.0)
     parallel (1.10.0)
-    parser (2.3.2.0)
+    parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
     procto (0.0.3)
@@ -112,7 +112,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -140,4 +140,4 @@ DEPENDENCIES
   rubocop (~> 0.41)
 
 BUNDLED WITH
-   1.13.6
+   1.14.4

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ MojFileUploaderApiClient.add_file(title: 'test', filename: 'test.txt', data: 'bl
 => {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757", :key=>"7c6aca2c-eb7a-4194-8166-9fd6ac82127b.test.txt"}
 ```
 
+With a folder name:
+
+```ruby
+MojFileUploaderApiClient.add_file(folder: 'subfolder', title: 'test', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757')
+=> {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757", :folder=>"subfolder", :key=>"7c6aca2c-eb7a-4194-8166-9fd6ac82127b.test.txt"}
+```
+
 Or you can use the `AddFile` client directly:
 
 ```ruby
@@ -59,6 +66,13 @@ MojFileUploaderApiClient.delete_file(collection_ref: 'a45c556f-a628-41d3-8c29-35
 => RequestError
 ```
 
+With a folder:
+
+```ruby
+MojFileUploaderApiClient.delete_file(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757', folder: 'subfolder', filename: 'test1.txt')
+=> RequestError
+```
+
 Or you can use the `DeleteFile` client directly:
 
 ```ruby
@@ -72,6 +86,14 @@ MojFileUploaderApiClient::DeleteFile.new(collection_ref: 'a45c556f-a628-41d3-8c2
 MojFileUploaderApiClient.list_files(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757')
 => {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757",
     :files=>[{:key=>"a45c556f-a628-41d3-8c29-351f84e63757/test1.txt", :title=>"test1.txt", :last_modified=>"2016-11-30T15:30:52.000Z"}]}
+```
+
+With a folder:
+
+```ruby
+MojFileUploaderApiClient.list_files(collection_ref: 'a45c556f-a628-41d3-8c29-351f84e63757', folder: 'subfolder')
+=> {:collection=>"a45c556f-a628-41d3-8c29-351f84e63757", :folder=>"subfolder",
+    :files=>[{:key=>"a45c556f-a628-41d3-8c29-351f84e63757/subfolder/test1.txt", :title=>"test1.txt", :last_modified=>"2016-11-30T15:30:52.000Z"}]}
 ```
 
 Or you can use the `ListFiles` client directly:

--- a/lib/mojfile_uploader_api_client/add_file.rb
+++ b/lib/mojfile_uploader_api_client/add_file.rb
@@ -1,10 +1,10 @@
 module MojFileUploaderApiClient
   class AddFile < MojFileUploaderApiClient::HttpClient
-    attr_accessor :collection_ref, :title, :filename, :data
+    attr_accessor :collection_ref, :folder, :filename, :data
 
-    def initialize(collection_ref: nil, title:, filename:, data:)
+    def initialize(collection_ref: nil, folder: nil, filename:, data:)
       self.collection_ref = collection_ref
-      self.title = title
+      self.folder = folder
       self.filename = filename
       self.data = data
     end
@@ -14,7 +14,9 @@ module MojFileUploaderApiClient
     end
 
     def payload
-      {file_title: title, file_filename: filename, file_data: data}
+      payload = {file_filename: filename, file_data: data}
+      payload[:folder] = folder if folder
+      payload
     end
 
     def endpoint

--- a/lib/mojfile_uploader_api_client/delete_file.rb
+++ b/lib/mojfile_uploader_api_client/delete_file.rb
@@ -1,9 +1,10 @@
 module MojFileUploaderApiClient
   class DeleteFile < MojFileUploaderApiClient::HttpClient
-    attr_accessor :collection_ref, :filename
+    attr_accessor :collection_ref, :folder, :filename
 
-    def initialize(collection_ref:, filename:)
+    def initialize(collection_ref:, folder: nil, filename:)
       self.collection_ref = collection_ref
+      self.folder = folder
       self.filename = filename
     end
 
@@ -12,7 +13,7 @@ module MojFileUploaderApiClient
     end
 
     def endpoint
-      [collection_ref, filename].join('/')
+      [collection_ref, folder, filename].compact.join('/')
     end
   end
 end

--- a/lib/mojfile_uploader_api_client/list_files.rb
+++ b/lib/mojfile_uploader_api_client/list_files.rb
@@ -1,9 +1,10 @@
 module MojFileUploaderApiClient
   class ListFiles < MojFileUploaderApiClient::HttpClient
-    attr_accessor :collection_ref
+    attr_accessor :collection_ref, :folder
 
-    def initialize(collection_ref:)
+    def initialize(collection_ref:, folder: nil)
       self.collection_ref = collection_ref
+      self.folder = folder
     end
 
     def verb
@@ -11,7 +12,7 @@ module MojFileUploaderApiClient
     end
 
     def endpoint
-      collection_ref
+      [collection_ref, folder].compact.join('/')
     end
   end
 end

--- a/lib/mojfile_uploader_api_client/version.rb
+++ b/lib/mojfile_uploader_api_client/version.rb
@@ -1,3 +1,3 @@
 module MojFileUploaderApiClient
-  VERSION = '0.2'
+  VERSION = '0.3'
 end

--- a/spec/mojfile_uploader_api_client/add_file_spec.rb
+++ b/spec/mojfile_uploader_api_client/add_file_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe MojFileUploaderApiClient::AddFile do
   let(:client) { RestClient::Request }
   let(:response) { instance_double('Response', code: 200, body: '{}') }
-  let(:file_arguments) { {title: 'test', filename: 'test.txt', data: 'bla bla bla'} }
+  let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', data: 'bla bla bla'} }
 
   subject { described_class.new(file_arguments) }
 
@@ -21,7 +21,7 @@ RSpec.describe MojFileUploaderApiClient::AddFile do
     end
 
     context 'when an existing collection_ref is provided' do
-      let(:file_arguments) { {title: 'test', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
+      let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
       let(:expected_endpoint) { 'abc-123-xxx/new' }
 
       it 'should build the endpoint without a collection_ref' do
@@ -41,7 +41,7 @@ RSpec.describe MojFileUploaderApiClient::AddFile do
     end
 
     context 'when an existing collection_ref is provided' do
-      let(:file_arguments) { {title: 'test', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
+      let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
       let(:expected_url) { 'http://example.com/abc-123-xxx/new' }
 
       it 'should build the full URL using base_url and endpoint' do
@@ -61,12 +61,26 @@ RSpec.describe MojFileUploaderApiClient::AddFile do
   end
 
   context 'payload' do
-    let(:expected_payload) { "{\"file_title\":\"test\",\"file_filename\":\"test.txt\",\"file_data\":\"bla bla bla\"}" }
+    context 'when a folder is given' do
+      let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
+      let(:expected_payload) { "{\"file_filename\":\"test.txt\",\"file_data\":\"bla bla bla\",\"folder\":\"subfolder\"}" }
 
-    it 'should send the specified payload' do
-      expect(client).to receive(:execute).with(hash_including(:method, :url, :headers, :verify_ssl, :open_timeout, :read_timeout,
-                                                              payload: expected_payload))
-      subject.call
+      it 'should send the specified payload' do
+        expect(client).to receive(:execute).with(hash_including(:method, :url, :headers, :verify_ssl, :open_timeout, :read_timeout,
+                                                                payload: expected_payload))
+        subject.call
+      end
+    end
+
+    context 'when no folder is given' do
+      let(:file_arguments) { {filename: 'test.txt', data: 'bla bla bla', collection_ref: 'abc-123-xxx'} }
+      let(:expected_payload) { "{\"file_filename\":\"test.txt\",\"file_data\":\"bla bla bla\"}" }
+
+      it 'should send the specified payload' do
+        expect(client).to receive(:execute).with(hash_including(:method, :url, :headers, :verify_ssl, :open_timeout, :read_timeout,
+                                                                payload: expected_payload))
+        subject.call
+      end
     end
   end
 end

--- a/spec/mojfile_uploader_api_client/delete_file_spec.rb
+++ b/spec/mojfile_uploader_api_client/delete_file_spec.rb
@@ -12,19 +12,44 @@ RSpec.describe MojFileUploaderApiClient::DeleteFile do
   end
 
   context 'endpoint' do
-    let(:expected_endpoint) { 'abc-123-xxx/test.txt' }
+    context 'without a folder' do
+      let(:file_arguments) { {filename: 'test.txt', collection_ref: 'abc-123-xxx'} }
+      let(:expected_endpoint) { 'abc-123-xxx/test.txt' }
 
-    it 'should build the endpoint using the collection_ref and the filename' do
-      expect(subject.endpoint).to eq(expected_endpoint)
+      it 'should build the endpoint using the collection_ref and the filename' do
+        expect(subject.endpoint).to eq(expected_endpoint)
+      end
+    end
+
+    context 'with a folder' do
+      let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', collection_ref: 'abc-123-xxx'} }
+      let(:expected_endpoint) { 'abc-123-xxx/subfolder/test.txt' }
+
+      it 'should build the endpoint using the collection_ref and the filename' do
+        expect(subject.endpoint).to eq(expected_endpoint)
+      end
     end
   end
 
   context 'URL' do
-    let(:expected_url) { 'http://example.com/abc-123-xxx/test.txt' }
+    context 'without a folder' do
+      let(:file_arguments) { {filename: 'test.txt', collection_ref: 'abc-123-xxx'} }
+      let(:expected_url) { 'http://example.com/abc-123-xxx/test.txt' }
 
-    it 'should build the full URL using base_url and endpoint' do
-      expect(client).to receive(:execute).with(hash_including(url: expected_url))
-      subject.call
+      it 'should build the full URL using base_url and endpoint' do
+        expect(client).to receive(:execute).with(hash_including(url: expected_url))
+        subject.call
+      end
+    end
+
+    context 'with a folder' do
+      let(:file_arguments) { {folder: 'subfolder', filename: 'test.txt', collection_ref: 'abc-123-xxx'} }
+      let(:expected_url) { 'http://example.com/abc-123-xxx/subfolder/test.txt' }
+
+      it 'should build the full URL using base_url and endpoint' do
+        expect(client).to receive(:execute).with(hash_including(url: expected_url))
+        subject.call
+      end
     end
   end
 

--- a/spec/mojfile_uploader_api_client/list_files_spec.rb
+++ b/spec/mojfile_uploader_api_client/list_files_spec.rb
@@ -12,19 +12,44 @@ RSpec.describe MojFileUploaderApiClient::ListFiles do
   end
 
   context 'endpoint' do
-    let(:expected_endpoint) { 'abc-123-xxx' }
+    context 'without a folder' do
+      let(:file_arguments) { {collection_ref: 'abc-123-xxx'} }
+      let(:expected_endpoint) { 'abc-123-xxx' }
 
-    it 'should build the endpoint using the collection_ref' do
-      expect(subject.endpoint).to eq(expected_endpoint)
+      it 'should build the endpoint using the collection_ref' do
+        expect(subject.endpoint).to eq(expected_endpoint)
+      end
+    end
+
+    context 'with a folder' do
+      let(:file_arguments) { {folder: 'subfolder', collection_ref: 'abc-123-xxx'} }
+      let(:expected_endpoint) { 'abc-123-xxx/subfolder' }
+
+      it 'should build the endpoint using the collection_ref' do
+        expect(subject.endpoint).to eq(expected_endpoint)
+      end
     end
   end
 
   context 'URL' do
-    let(:expected_url) { 'http://example.com/abc-123-xxx' }
+    context 'without a folder' do
+      let(:file_arguments) { {collection_ref: 'abc-123-xxx'} }
+      let(:expected_url) { 'http://example.com/abc-123-xxx' }
 
-    it 'should build the full URL using base_url and endpoint' do
-      expect(client).to receive(:execute).with(hash_including(url: expected_url))
-      subject.call
+      it 'should build the full URL using base_url and endpoint' do
+        expect(client).to receive(:execute).with(hash_including(url: expected_url))
+        subject.call
+      end
+    end
+
+    context 'with a folder' do
+      let(:file_arguments) { {folder: 'subfolder', collection_ref: 'abc-123-xxx'} }
+      let(:expected_url) { 'http://example.com/abc-123-xxx/subfolder' }
+
+      it 'should build the full URL using base_url and endpoint' do
+        expect(client).to receive(:execute).with(hash_including(url: expected_url))
+        subject.call
+      end
     end
   end
 

--- a/spec/mojfile_uploader_api_client_spec.rb
+++ b/spec/mojfile_uploader_api_client_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe MojFileUploaderApiClient do
     let(:client_class) { MojFileUploaderApiClient::AddFile }
     let(:params) {{
       collection_ref: '123',
-      title: 'title',
       filename: 'filename',
       data: 'data'
     }}


### PR DESCRIPTION
Now that the uploader supports folders inside collections, this adds
folder support to the gem too.

c.f. https://github.com/ministryofjustice/mojfile-uploader/pull/27