### PR TITLE
Add error details to error instances

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -711,7 +711,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mojfile-uploader-api-client (0.4)
+    mojfile-uploader-api-client (0.5)
       rest-client (~> 2.0.0)
 
 GEM
@@ -79,7 +79,7 @@ GEM
     pry-byebug (3.4.1)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     rake (10.5.0)
     regexp_parser (0.3.6)
     rest-client (2.0.0)
@@ -99,8 +99,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.45.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -116,7 +116,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (1.1.1)
+    unicode-display_width (1.1.3)
     unparser (0.2.5)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)

--- a/lib/mojfile_uploader_api_client.rb
+++ b/lib/mojfile_uploader_api_client.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'rest-client'
 require 'mojfile_uploader_api_client/version'
+require 'mojfile_uploader_api_client/errors'
 require 'mojfile_uploader_api_client/response'
 require 'mojfile_uploader_api_client/http_client'
 require 'mojfile_uploader_api_client/file_reference'
@@ -13,11 +14,6 @@ module MojFileUploaderApiClient
   INFECTED_FILE_RESPONSE_CODE = 400
   NOT_FOUND_RESPONSE_CODE = 404
 
-  class Unavailable < StandardError; end
-  class RequestError < StandardError; end
-  class InfectedFileError < StandardError; end
-  class NotFoundError < StandardError; end
-
   def self.add_file(params)
     response = AddFile.new(params).call
 
@@ -26,14 +22,14 @@ module MojFileUploaderApiClient
     elsif response.code.equal?(INFECTED_FILE_RESPONSE_CODE)
       raise InfectedFileError
     else
-      raise RequestError
+      raise RequestError.new('Could not add file', response.code, response.body)
     end
   end
 
   def self.delete_file(params)
     response = DeleteFile.new(params).call
 
-    raise RequestError unless response.success?
+    raise RequestError.new('Could not delete file', response.code, response.body) unless response.success?
     response.body
   end
 
@@ -45,7 +41,7 @@ module MojFileUploaderApiClient
     elsif response.code.equal?(NOT_FOUND_RESPONSE_CODE)
       raise NotFoundError
     else
-      raise RequestError
+      raise RequestError.new('Could not list files', response.code, response.body)
     end
   end
 end

--- a/lib/mojfile_uploader_api_client/errors.rb
+++ b/lib/mojfile_uploader_api_client/errors.rb
@@ -1,0 +1,23 @@
+module MojFileUploaderApiClient
+  class RequestError < StandardError
+    attr_reader :code, :body
+
+    def initialize(message, code, body)
+      super(message)
+      @code = code
+      @body = body
+    end
+  end
+
+  class UnparsableResponseError < RuntimeError
+    attr_reader :raw_body
+
+    def initialize(message, raw_body)
+      super(message)
+      @raw_body = raw_body
+    end
+  end
+
+  class InfectedFileError < StandardError; end
+  class NotFoundError < StandardError; end
+end

--- a/lib/mojfile_uploader_api_client/response.rb
+++ b/lib/mojfile_uploader_api_client/response.rb
@@ -1,8 +1,6 @@
 module MojFileUploaderApiClient
   class Response
-    class UnparsableResponseError < RuntimeError; end
-
-    attr_accessor :code
+    attr_accessor :code, :raw_body
 
     def initialize(code:, body:)
       @code = code
@@ -24,10 +22,10 @@ module MojFileUploaderApiClient
     private
 
     def parse_body
-      return if @raw_body.nil? || @raw_body.empty?
-      JSON.parse(@raw_body, symbolize_names: true)
+      return if raw_body.nil? || raw_body.empty?
+      JSON.parse(raw_body, symbolize_names: true)
     rescue JSON::ParserError
-      raise UnparsableResponseError
+      raise UnparsableResponseError.new('Invalid JSON response', raw_body)
     end
   end
 end

--- a/lib/mojfile_uploader_api_client/version.rb
+++ b/lib/mojfile_uploader_api_client/version.rb
@@ -1,3 +1,3 @@
 module MojFileUploaderApiClient
-  VERSION = '0.4'
+  VERSION = '0.5'
 end

--- a/spec/mojfile_uploader_api_client/http_client_spec.rb
+++ b/spec/mojfile_uploader_api_client/http_client_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
         response = subject.response
 
         expect(response.code).to eq(404)
-        expect { response.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
+        expect { response.body }.to raise_error(MojFileUploaderApiClient::UnparsableResponseError)
       end
     end
 

--- a/spec/mojfile_uploader_api_client/response_spec.rb
+++ b/spec/mojfile_uploader_api_client/response_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe MojFileUploaderApiClient::Response do
       let(:body) { 'sadifuygwi3P982(*#Q$&(*' }
 
       it 'raises an error' do
-        expect { subject.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
+        expect { subject.body }.to raise_error(MojFileUploaderApiClient::UnparsableResponseError, 'Invalid JSON response') do |error|
+          expect(error.raw_body).to eq(body)
+        end
       end
     end
   end

--- a/spec/mojfile_uploader_api_client/status_spec.rb
+++ b/spec/mojfile_uploader_api_client/status_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe MojFileUploaderApiClient::Status do
         response = subject.response
 
         expect(response.code).to eq(500)
-        expect { response.body }.to raise_error(MojFileUploaderApiClient::Response::UnparsableResponseError)
+        expect { response.body }.to raise_error(MojFileUploaderApiClient::UnparsableResponseError)
       end
     end
 

--- a/spec/mojfile_uploader_api_client_spec.rb
+++ b/spec/mojfile_uploader_api_client_spec.rb
@@ -44,7 +44,11 @@ RSpec.describe MojFileUploaderApiClient do
       let(:code) { 402 }
 
       it 'raises RequestError' do
-        expect { client.add_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+        expect(response).to receive(:body).and_return(body)
+        expect { client.add_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError, 'Could not add file') do |error|
+          expect(error.code).to eq(402)
+          expect(error.body).to eq(body)
+        end
       end
     end
   end
@@ -71,7 +75,12 @@ RSpec.describe MojFileUploaderApiClient do
       let(:code) { 402 }
 
       it 'raises RequestError' do
-        expect { client.delete_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+        expect(response).to receive(:body).and_return(body)
+
+        expect { client.delete_file(params) }.to raise_error(MojFileUploaderApiClient::RequestError, 'Could not delete file') do |error|
+          expect(error.code).to eq(402)
+          expect(error.body).to eq(body)
+        end
       end
     end
   end
@@ -106,7 +115,11 @@ RSpec.describe MojFileUploaderApiClient do
       let(:code) { 402 }
 
       it 'raises RequestError' do
-        expect { client.list_files(params) }.to raise_error(MojFileUploaderApiClient::RequestError)
+        expect(response).to receive(:body).and_return(body)
+        expect { client.list_files(params) }.to raise_error(MojFileUploaderApiClient::RequestError, 'Could not list files') do |error|
+          expect(error.code).to eq(402)
+          expect(error.body).to eq(body)
+        end
       end
     end
   end


### PR DESCRIPTION
In order to be able to debug production issues, we need to avoid
swallowing the root cause of uploader errors in the `RequestError`
class. This adds them in to the error object so we can later view
them in our error reporting.

- Update error classes to include response body and status code
- Move errors into separate file
- Update Rubocop to get rid of Ruby 2.4.0 warnings
- Version bump