### PR TITLE
Switch on encryption, by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mojfile-uploader-api-client (0.5)
+    mojfile-uploader-api-client (0.6)
       rest-client (~> 2.0.0)
 
 GEM
@@ -140,4 +140,4 @@ DEPENDENCIES
   rubocop (~> 0.41)
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/lib/mojfile_uploader_api_client/http_client.rb
+++ b/lib/mojfile_uploader_api_client/http_client.rb
@@ -3,7 +3,11 @@ module MojFileUploaderApiClient
     attr_accessor :response
 
     DEFAULT_OPTIONS = {
-      headers: {'Content-Type' => 'application/json', 'Accept' => 'application/json'},
+      headers: {
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json',
+        'x-amz-server-side-encryption' => 'AES256'
+      },
       verify_ssl: false,
       open_timeout: 5,
       read_timeout: 15

--- a/lib/mojfile_uploader_api_client/version.rb
+++ b/lib/mojfile_uploader_api_client/version.rb
@@ -1,3 +1,3 @@
 module MojFileUploaderApiClient
-  VERSION = '0.5'
+  VERSION = '0.6'
 end

--- a/spec/mojfile_uploader_api_client/http_client_spec.rb
+++ b/spec/mojfile_uploader_api_client/http_client_spec.rb
@@ -6,10 +6,15 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
 
   let(:client) { RestClient::Request }
   let(:client_response) { instance_double('Response', code: 200, body: '{}') }
+  let(:headers) {{
+    'Content-Type' => 'application/json',
+    'Accept' => 'application/json',
+    'x-amz-server-side-encryption' => 'AES256'
+  }}
 
   describe 'default options' do
     it 'should have a default set of client options' do
-      expect(subject.options).to eq({headers: {"Content-Type" => "application/json", "Accept" => "application/json"},
+      expect(subject.options).to eq({headers: headers,
                                      verify_ssl: false,
                                      open_timeout: 5,
                                      read_timeout: 15})
@@ -30,7 +35,7 @@ RSpec.describe MojFileUploaderApiClient::HttpClient do
     end
 
     it 'should be able to override any of the default client options' do
-      expect(subject.options).to eq({headers: {"Content-Type" => "application/json", "Accept" => "application/json"},
+      expect(subject.options).to eq({headers: headers,
                                      verify_ssl: true,
                                      open_timeout: 100,
                                      read_timeout: 500})


### PR DESCRIPTION
This commit sets the encryption type to AES256 for
all files that are uploaded to S3. This means S3
will store the files encrypted at rest, and will
transparently decrypt the data during all
authorised accesses of the object.